### PR TITLE
attachment image not found using default server config , without url …

### DIFF
--- a/view/frontend/templates/product/view/list.phtml
+++ b/view/frontend/templates/product/view/list.phtml
@@ -21,8 +21,13 @@ $_items = $block->getReviewsCollection()->getItems();
 $format = $block->getDateFormat() ?: \IntlDateFormatter::SHORT;
 
 $_objectManager = \Magento\Framework\App\ObjectManager::getInstance();
-$storeManager = $_objectManager->get('\Magento\Store\Model\StoreManagerInterface');
-$mediaDirectoryPath= $storeManager->getStore()->getBaseUrl(\Magento\Framework\UrlInterface::URL_TYPE_WEB).'pub/media/review_images';
+$_storeManager = $_objectManager->get('\Magento\Store\Model\StoreManagerInterface');
+
+$mediaDirectoryPath = $_storeManager->getStore()->getBaseUrl(\Magento\Framework\UrlInterface::URL_TYPE_MEDIA) . 'review_images';
+
+if(strpos($mediaDirectoryPath,'/index.php/') !== false){
+    $mediaDirectoryPath = str_replace('/index.php/','/',$mediaDirectoryPath);    
+}
 
 ?>
 <?php if (count($_items)): ?>

--- a/view/frontend/templates/product/view/list.phtml
+++ b/view/frontend/templates/product/view/list.phtml
@@ -21,7 +21,8 @@ $_items = $block->getReviewsCollection()->getItems();
 $format = $block->getDateFormat() ?: \IntlDateFormatter::SHORT;
 
 $_objectManager = \Magento\Framework\App\ObjectManager::getInstance();
-$mediaDirectoryPath = $this->getUrl('pub/media/review_images');
+$storeManager = $_objectManager->get('\Magento\Store\Model\StoreManagerInterface');
+$mediaDirectoryPath= $storeManager->getStore()->getBaseUrl(\Magento\Framework\UrlInterface::URL_TYPE_WEB).'pub/media/review_images';
 
 ?>
 <?php if (count($_items)): ?>


### PR DESCRIPTION
# There are the "index.php" appeared in the attachment image URL, looked like this ( if I were not enabling the Nginx rewrite ):

http://example.com/index.php/pub/media/review_images/e/5/e5c931bd-dfec-444d-9855-b3979f45ba28_1.jpg
